### PR TITLE
Fix für issue gdi-by#97

### DIFF
--- a/src/main/java/de/bayern/gdi/utils/FileResponseHandler.java
+++ b/src/main/java/de/bayern/gdi/utils/FileResponseHandler.java
@@ -35,7 +35,7 @@ import org.apache.http.HttpStatus;
 
 import org.apache.http.client.ClientProtocolException;
 import org.apache.http.client.ResponseHandler;
-import org.apache.http.client.methods.HttpRequestBase;
+import org.apache.http.client.methods.HttpUriRequest;
 
 /**
  * File handler for HttpClient.
@@ -68,19 +68,19 @@ public class FileResponseHandler implements ResponseHandler<Boolean> {
 
     private File file;
 
-    private HttpRequestBase request;
+    private HttpUriRequest request;
 
     private WrapInputStreamFactory wrapFactory;
 
     public FileResponseHandler() {
     }
 
-    public FileResponseHandler(File file, HttpRequestBase request) {
+    public FileResponseHandler(File file, HttpUriRequest request) {
         this(file, null, request);
     }
 
     public FileResponseHandler(File file, WrapInputStreamFactory wrapFactory,
-            HttpRequestBase request) {
+            HttpUriRequest request) {
         this.file = file;
         this.wrapFactory = wrapFactory;
         this.request = request;


### PR DESCRIPTION
Moin,
hiermit erhalten Sie den Fix für gdi-by#97 . 

Dabei haben wir festgestellt, dass es sich hierbei nicht wie angenommen um einen Refactoring-Bug handelt. Der Fehler muss bereits seit dem 15. Juni 2017 bestanden haben. Verantwortlich war aus unsere Sicht der Commit a02c25104a0b608cc123d0e85d1d8e777930e440 vom 15. Juni 2017.