### PR TITLE
Attribut matchAction="Any" im WFS-Filter korrigieren

### DIFF
--- a/src/main/java/de/bayern/gdi/services/FilterEncoder.java
+++ b/src/main/java/de/bayern/gdi/services/FilterEncoder.java
@@ -26,11 +26,15 @@ import org.geotools.xml.Configuration;
 import org.geotools.xml.Encoder;
 import org.opengis.filter.Filter;
 import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 
 import javax.xml.transform.TransformerException;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -116,7 +120,9 @@ public class FilterEncoder {
             encoder.setIndentSize(INDENTSIZE);
             encoder.setOmitXMLDeclaration(true);
 
-            return encoder.encodeAsDOM(filter, FES.Filter);
+            Document fesFilter = encoder.encodeAsDOM(filter, FES.Filter);
+            fixFilterIfRequired(fesFilter);
+            return fesFilter;
         } catch (IOException | TransformerException | SAXException e) {
             throw new ConverterException(
                 "Converting from CQL to Filter failed", e);
@@ -125,6 +131,44 @@ public class FilterEncoder {
 
     private String cleanUpFeatureTypeName(String where) {
         return where.replace("\"", "").trim();
+    }
+
+
+    private List<String> binaryComparisonOpTypes = Arrays.asList(
+        "PropertyIsEqualTo",
+        "PropertyIsNotEqualTo",
+        "PropertyIsLessThan",
+        "PropertyIsGreaterThan",
+        "PropertyIsLessThanOrEqualTo",
+        "PropertyIsGreaterThanOrEqualTo");
+
+    private void fixFilterIfRequired(Document fesFilter) {
+        Node filter = fesFilter.getFirstChild();
+        if (filter != null && filter.hasChildNodes()) {
+            NodeList childNodes = filter.getChildNodes();
+            fixChilds(childNodes);
+        }
+    }
+
+    private void fixChilds(NodeList childNodes) {
+        if (childNodes != null && childNodes.getLength() > 0) {
+            for (int i = 0; i < childNodes.getLength(); i++) {
+                Node child = childNodes.item(i);
+                String localName = child.getLocalName();
+                if (child instanceof Element
+                    && binaryComparisonOpTypes.contains(localName)) {
+                    String matchActionValue = ((Element) child).
+                        getAttribute("matchAction");
+                    if ("ANY".equals(matchActionValue)) {
+                        ((Element) child).setAttribute("matchAction",
+                            "Any");
+                    }
+                }
+                if (child.hasChildNodes()) {
+                    fixChilds(child.getChildNodes());
+                }
+            }
+        }
     }
 
     /**

--- a/src/test/java/de/bayern/gdi/processor/WFSPostParamsBuilderTest.java
+++ b/src/test/java/de/bayern/gdi/processor/WFSPostParamsBuilderTest.java
@@ -139,8 +139,7 @@ public class WFSPostParamsBuilderTest extends WFS20ResourceTestBase {
             usedVars, meta);
         printDocument(wfsRequest);
 
-        // Fails cause of ANY (instead of Any)
-        // assertThat(the(wfsRequest), conformsTo(w3cXmlSchemaFrom(wfs())));
+        assertThat(the(wfsRequest), conformsTo(w3cXmlSchemaFrom(wfs())));
 
         assertThat(the(wfsRequest), hasXPath(
             "/wfs:GetFeature/wfs:Query/@srsName",
@@ -201,8 +200,7 @@ public class WFSPostParamsBuilderTest extends WFS20ResourceTestBase {
             usedVars, meta);
         printDocument(wfsRequest);
 
-        // Fails cause of ANY (instead of Any)
-        // assertThat(the(wfsRequest), conformsTo(w3cXmlSchemaFrom(wfs())));
+        assertThat(the(wfsRequest), conformsTo(w3cXmlSchemaFrom(wfs())));
 
         assertThat(the(wfsRequest), hasXPath(
             "count(/wfs:GetFeature/wfs:Query)",
@@ -241,8 +239,7 @@ public class WFSPostParamsBuilderTest extends WFS20ResourceTestBase {
             usedVars, meta);
         printDocument(wfsRequest);
 
-        // Fails cause of ANY (instead of Any)
-        // assertThat(the(wfsRequest), conformsTo(w3cXmlSchemaFrom(wfs())));
+        assertThat(the(wfsRequest), conformsTo(w3cXmlSchemaFrom(wfs())));
 
         assertThat(the(wfsRequest), hasXPath(
             "count(/wfs:GetFeature/wfs:Query)",

--- a/src/test/java/de/bayern/gdi/services/FilterEncoderTest.java
+++ b/src/test/java/de/bayern/gdi/services/FilterEncoderTest.java
@@ -81,6 +81,45 @@ public class FilterEncoderTest {
         assertThat(the(filter), hasXPath("/fes:Filter", namespaceContext()));
     }
 
+
+    /**
+     * Test creation of valid CQL.
+     *
+     * @throws Exception e
+     */
+    @Test
+    public void testFilterEqual() throws Exception {
+        FilterEncoder filterEncoder = new FilterEncoder();
+        List<FilterEncoder.QueryToFeatureType> filters =
+            filterEncoder.initializeQueries("\"bvv:sch\" = '09774'");
+
+        assertThat(filters.size(), is(1));
+
+        Document filter = filters.get(0).getFilter();
+        assertThat(the(filter), conformsTo(w3cXmlSchemaFrom(fes())));
+        assertThat(the(filter), hasXPath("/fes:Filter", namespaceContext()));
+    }
+
+
+    /**
+     * Test creation of valid CQL.
+     *
+     * @throws Exception e
+     */
+    @Test
+    public void testFilterEqualAndLessThan() throws Exception {
+        FilterEncoder filterEncoder = new FilterEncoder();
+        List<FilterEncoder.QueryToFeatureType> filters =
+            filterEncoder.initializeQueries(
+                "\"bvv:sch\" = '09774' AND \"bvv:abc\" <= 9");
+
+        assertThat(filters.size(), is(1));
+
+        Document filter = filters.get(0).getFilter();
+        assertThat(the(filter), conformsTo(w3cXmlSchemaFrom(fes())));
+        assertThat(the(filter), hasXPath("/fes:Filter", namespaceContext()));
+    }
+
     /**
      * Test creation of valid CQL.
      *
@@ -123,7 +162,7 @@ public class FilterEncoderTest {
         assertThat(filters.size(), is(2));
 
         Document firstFilter = filters.get(0).getFilter();
-        //assertThat(the(firstFilter), conformsTo(w3cXmlSchemaFrom(fes())));
+        assertThat(the(firstFilter), conformsTo(w3cXmlSchemaFrom(fes())));
         assertThat(the(firstFilter), hasXPath("/fes:Filter",
             namespaceContext()));
 


### PR DESCRIPTION
Das Attribut matchAction="ANY" in einem durch den DLS generierten WFS-Filter wird mit diesem Pull Request auf matchAction="Any" korrigiert.
Somit sind Requests mit den WFS-Filter Operationen "PropertyIsEqualTo", "PropertyIsNotEqualTo", "PropertyIsLessThan", "PropertyIsGreaterThan", "PropertyIsLessThanOrEqualTo" und "PropertyIsGreaterThanOrEqualTo" nun, in Hinsicht auf das Attribut "matchAction", korrekt und es wird die erwartete Response zurückgegeben, wenn beispielsweise die deegree Demo [1] zum Testen verwendet wird.

Fehler wurde in https://github.com/gdi-by/downloadclient-dev/issues/1#issuecomment-410657215 beschrieben.

Der Fehler resultiert aus einem Bug in GeoTools.
Dieser wurde dem GeoTools Projekt gemeldet: https://osgeo-org.atlassian.net/browse/GEOT-6092

[1] http://demo.deegree.org/utah-workspace/services/wfs?service=WFS&request=GetCapabilities