### PR TITLE
#44 Fixes build issue with maven-shade-plugin generated JAR

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,12 @@
                                         <exclude>META-INF/*.RSA</exclude>
                                     </excludes>
                                 </filter>
+                                <filter>
+                                    <artifact>org.openjfx</artifact>
+                                    <includes>
+                                        <include>**</include>
+                                    </includes>
+                                </filter>
                             </filters>
                             <transformers>
                                 <!-- merges META-INF/services/ entries instead of overwriting -->


### PR DESCRIPTION
Fehlerbehebung für Issue https://github.com/gdi-by/downloadclient-dev/issues/44 unter Windows/Linux/macOS und Oracle JDK 11.