### PR TITLE
Improved startup scripts for Java 11 with JavaFX SKD 11

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,11 +20,11 @@ Der Download-Client steht in Form von Zip-Archiven für Windows und Linux hier b
 
 Für beide Betriebssysteme steht je eine Version des Download-Client für die Java Version 1.8 und Java 11.0 zur Verfügung.
 
-Prüfen Sie vor dem Download der Datei die installierte Java-Version mit dem Befehl `java -version` und wählen Sie entsprechend
+Prüfen Sie vor dem Download der Datei die installierte Java-Version mit dem Befehl ``java -version`` und wählen Sie entsprechend
 der angezeigten Java-Version das passende Installationspaket für den Download-Client aus.
 
-Wenn kein Java installiert ist, dann installieren Sie wie
-im folgenden Kapitel beschrieben eine für das Betriebssystem passende Java-Version.
+Wenn kein Java installiert ist, dann installieren Sie wie im folgenden Kapitel beschrieben
+eine für das Betriebssystem passende Java-Version.
 
 
 Voraussetzungen - Softwareumgebung
@@ -42,10 +42,24 @@ Aktuelle Java-Versionen können hier heruntergeladen werden:
     - AdoptOpenJDK (8 und 11): https://adoptopenjdk.net/ (JavaFX **nicht** enthalten)
     - Amazon Corretto (8 und 11): https://docs.aws.amazon.com/corretto/ (JavaFX **nicht** enthalten)
 
-Für die diese beiden Java Versionen muss zusätzlich das passende `JavaFX-SDK <https://openjfx.io>`_ installiert sein.
-
 Hinweis:
   Bitte beachten Sie die Lizenzbedingungen der jeweiligen Hersteller!
+
+JavaFX-Bibliothek
+^^^^^^^^^^^^^^^^^
+
+Für die OpenJDK-Distributionen ohne JavaFX muss zusätzlich das zum Betriebssystem passende `JavaFX-SDK <https://openjfx.io>`_ installiert sein.
+Die Installation des JavaFX-SDK erfolgt nach erfolgreichem Download durch Entpacken des Zip-Archivs im Dateisystem und setzen der Umgebungsvariable
+``JAVAFX_HOME``.
+
+Unter Linux z.B. durch:
+
+``export JAVAFX_HOME=/path/to/javafx-sdk-11.0.2``
+
+unter Windows durch:
+
+``set JAVAFX_HOME=C:\path\to\javafx-sdk-11.0.2``
+
 
 Installationspakte
 ------------------
@@ -151,9 +165,9 @@ Download von Datensätzen eines WFS 2.0
 Beim Download von Datensätzen eines WFS 2.0 werden in der Datensatz-Auswahlliste sowohl alle FeatureTypes des WFS als auch alle vordefinierten Abfragen ("Stored Queries" - wenn vorhanden) zum Download angeboten. 
 Standardmäßig ist der erste Eintrag der Liste ausgewählt.
  
-*********************
+
 Vordefinierte Abfrage
-*********************
+^^^^^^^^^^^^^^^^^^^^^
 
 Bei Auswahl einer vordefinierten Abfrage passt sich der Datensatzvarianten-Auswahlbereich dahingehend an, dass die Abfrageparameter als Eingabefelder sowie (falls vorhanden) eine Beschreibung der vordefinierten Abfrage erscheinen. Zusätzlich kann eines der vom Dienst nativ angebotenen Ausgabedatenformate gewählt werden.
 
@@ -165,9 +179,9 @@ Bei Auswahl einer vordefinierten Abfrage passt sich der Datensatzvarianten-Auswa
 Im oben dargestellten Beispiel wird als Suchbegriff *"Gemeinde"* im entsprechenden Suchfenster eingegeben und der Downloaddienst *"Verwaltungsgrenzen - WFS 2.0 DemoServer"* verwendet. Die vordefinierte Abfrage lautet *"Abfrage einer Gemeinde über den Gemeindeschlüssel"*. 
 Dabei wird die Grenze der Stadt München mit dem Schlüssel *09162000* im Format *KML* abgefragt. Mit Klick auf den Button „Download start...“ unter Angabe eines Zielordners wird der Download angestoßen.
 
-************
+
 FeatureTypes
-************
+^^^^^^^^^^^^
 
 Für jeden über den ausgewählten WFS bereitgestellten FeatureType wird ein Eintrag in der Auswahlliste mit dem Zusatz *"(BBOX)"* angegeben.
 So kann der Nutzer über die Kartenkomponente ein Begrenzungsrechteck (BBOX) aufziehen und so einen Abfragebereich definieren, für welchen er Daten beziehen möchte. Um den Abfragebereich im Kartenfenster
@@ -182,9 +196,9 @@ Zusätzlich kann noch ein Ausgabedatenformat und ein Koordinatenreferenzsystem g
 
 Im oben dargestellten Beispiel wird als Suchbegriff *"Gemeinde"* im entsprechenden Suchfenster eingegeben und der Downloaddienst *"Verwaltungsgrenzen - WFS 2.0 DemoServer"* verwendet. Anschließend wird der FeatureType *"Gemeinden Bayern"* ausgewählt und auf der Karte ein Rechteck aufgezogen. Somit können sämtliche Gemeindegrenzen heruntergeladen werden, welche sich mit dem Begrenzungsrechteck berühren. Als Ausgabedatenformat wird *KML* gewählt, das Koordinatenreferenzsystem soll *WGS84* sein.
 
-****************************************
+
 Weitere Funktionen der Kartenkomponenten
-****************************************
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 * Über die Schaltflächen "+" und "-" innerhalb der Kartenkomponente kann der Kartenausschnitt durch Zoom-in und Zoom-out verändert werden. Diese Funktionalität ist auch über das Scroll-Rad der Maus (mittlere Maustaste) aufrufbar.
 
@@ -194,9 +208,9 @@ Weitere Tastenkombinationen:
 - ``SHIFT`` + ``linke Maustaste``: Zieht einen Bereich auf (blaues Rechteck) mit anschließendem Zoom-in auf den ausgewählten Bereich.
 - ``SHIFT`` + ``ALT`` + ``linke Maustaste``: Ausrichtung der Karte verändern (es wird zusätzlich eine Schaltfläche rechts oben innerhalb der Kartenkomponente angezeigt, über die die Karte wieder in die ursprüngliche Nord-Süd-Ausrichtung ausgerichtet werden kann).
 
-***********************
+
 Abfragen mit CQL-Filter
-***********************
+^^^^^^^^^^^^^^^^^^^^^^^
 
 Neben der Auswahl über ein Begrenzungsrechteck (BBOX) wird für jeden bereitgestellten FeatureType ein Eintrag in der Auswahlliste mit dem Zusatz *"(Filter)"* angegeben.
 So kann der Benutzer mit Angabe eines CQL-Ausdrucks [#f2]_ im Textfeld die Ausgabe des WFS filtern.
@@ -208,9 +222,9 @@ So kann der Benutzer mit Angabe eines CQL-Ausdrucks [#f2]_ im Textfeld die Ausga
 
 Im oben dargestellten Beispiel wird der FeatureType *"Gemeinden"* über den CQL-Ausdruck auf dem Attribut *"bvv:sch"* mit dem Wert *09162000* gefiltert.
 
-************************
+
 Typübergreifende Abfrage
-************************
+^^^^^^^^^^^^^^^^^^^^^
 
 Zusätzlich zu der Filterfunktion je FeatureType kann auch ein typübergreifender Filter definiert werden. Dazu muss in der Auswahl der Eintrag "Typübergreifende Abfrage (Filter)" ausgewählt werden.
 Im Textfeld kann der Benutzer einen oder mehrere CQL-Ausdrücke [#f2]_ eingeben und somit die Ausgabe des WFS filtern.
@@ -326,7 +340,7 @@ Weitere Informationen, wie das Anwendungs-Logfile angepasst werden kann, können
 .. [#f3] Apache Log4j2 Dokumentation https://logging.apache.org/log4j/2.x/manual/configuration.html
 
 Ausführungswiederholung
----------------------------
+-----------------------
 
 Eine Download-Konfiguration kann über den entsprechenden Button als XML-Datei (Dateiname config<DatumUhrzeitNr>.xml) gespeichert und im Download-Client über das Menü *Datei* --> *Download-Konfiguration laden* erneut geladen werden. Zudem kann die gespeicherte Download-Konfiguration über ein Konsolenprogramm erneut bzw. in regelmäßigen Intervallen ausgeführt werden. 
  

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -60,6 +60,11 @@ unter Windows durch:
 
 ``set JAVAFX_HOME=C:\path\to\javafx-sdk-11.0.2``
 
+Gdal-Bibliothek
+^^^^^^^^^^^^^^^
+
+Unter Linux und macOS ist die Installation von gdal/ogr erforderlich. Es muss die Version 2.1 oder höher installiert sein.
+
 
 Installationspakte
 ------------------

--- a/misc/scripts/startup-headless.bat
+++ b/misc/scripts/startup-headless.bat
@@ -2,6 +2,9 @@
 @echo GDI-BY Downloadclient
 @echo ===============================================
 @echo Setting up an environment.
+@setlocal EnableDelayedExpansion
+
+SET "SYS_PATH=%PATH%"
 SET dlc=%~dp0
 SET dlc=%dlc:\\=\%
 SET "PATH=%dlcbin%;%dlcdll%;%PATH%"
@@ -16,4 +19,38 @@ call %dlc%bin\gisinternals\SDKShell.bat setenv
 @echo Starting the downloadclient.
 @echo -----------------------------------------------
 
-java -jar downloadclient.jar --headless %dlstep% --config=config
+where java >nul 2>nul
+if %errorlevel%==1 (
+    @echo "No Java Runtime (JRE/JDK) installed! Please read the documentation for further information."
+    goto exit
+) 
+  for /f "tokens=3" %%g in ('java -version 2^>^&1 ^| findstr /i "version"') do (
+    set JAVAVER=%%g
+  )
+  set JAVAVER=%JAVAVER:"=%
+  @echo Java version=%JAVAVER%
+
+  IF "%JAVAVER:~0,3%"=="1.8" (
+    @echo "Starting GDI-BY Downloadclient using Java version 1.8"
+    java -jar downloadclient.jar --headless %dlstep% --config=config
+    goto exit
+  ) else (
+    IF "%JAVAVER:~0,4%"=="11.0" (      
+      IF "%JAVAFX_HOME%"=="" (  
+        @echo "JAVAFX_HOME is not set. Please read the documentation for further information."
+        goto exit
+      ) else (
+        @echo "Starting GDI-BY Downloadclient using Java version 11"
+        java --module-path %JAVAFX_HOME%\lib --add-modules=javafx.base,javafx.controls,javafx.fxml,javafx.graphics,javafx.web --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.invoke=ALL-UNNAMED --add-opens=javafx.graphics/javafx.application=ALL-UNNAMED --add-opens=javafx.graphics/javafx.geometry=ALL-UNNAMED --add-exports javafx.graphics/com.sun.javafx.sg.prism=ALL-UNNAMED --add-exports javafx.graphics/com.sun.javafx.scene=ALL-UNNAMED --add-exports javafx.graphics/com.sun.javafx.util=ALL-UNNAMED --add-exports javafx.base/com.sun.javafx.logging=ALL-UNNAMED --add-exports javafx.graphics/com.sun.prism=ALL-UNNAMED --add-exports javafx.graphics/com.sun.glass.ui=ALL-UNNAMED --add-exports javafx.graphics/com.sun.javafx.geom.transform=ALL-UNNAMED --add-exports javafx.graphics/com.sun.javafx.tk=ALL-UNNAMED --add-exports javafx.graphics/com.sun.glass.utils=ALL-UNNAMED --add-exports javafx.graphics/com.sun.javafx.font=ALL-UNNAMED --add-exports javafx.controls/com.sun.javafx.scene.control=ALL-UNNAMED --add-exports javafx.graphics/com.sun.javafx.scene.input=ALL-UNNAMED --add-exports javafx.graphics/com.sun.javafx.geom=ALL-UNNAMED --add-exports javafx.graphics/com.sun.javafx.application=ALL-UNNAMED --add-exports javafx.graphics/com.sun.prism.paint=ALL-UNNAMED --add-exports javafx.graphics/com.sun.scenario.effect=ALL-UNNAMED --add-exports javafx.graphics/com.sun.javafx.text=ALL-UNNAMED --add-exports javafx.graphics/com.sun.javafx.iio=ALL-UNNAMED -jar downloadclient.jar --headless %dlstep% --config=config
+        goto exit
+      )
+    ) else (
+      @echo "No suitable Java version found. Please read the documentation for further information."
+      goto exit
+    )
+  )
+
+:exit
+@set "PATH=%SYS_PATH%"
+@set SYS_PATH=
+@set _path=

--- a/misc/scripts/startup-headless.sh
+++ b/misc/scripts/startup-headless.sh
@@ -19,8 +19,13 @@ if [[ "$_java" ]]; then
         echo "Starting GDI-BY Downloadclient in headless mode using Java version 1.8"
         $_java -jar downloadclient.jar -headless $FILE --config=config $@
     elif [[ "$version" = "11.0"* ]]; then
-        echo "Starting GDI-BY Downloadclient in headless mode using Java version 11"
-        $_java -jar downloadclient.jar -headless $FILE --config=config $@
+        if [[ -n "$JAVAFX_HOME" ]]; then
+            echo "Starting GDI-BY Downloadclient in headless mode using Java version 11"
+            echo "Using JAVAFX in JAVAFX_HOME=$JAVAFX_HOME"
+            $_java --module-path $JAVAFX_HOME/lib --add-modules=javafx.base,javafx.controls,javafx.fxml,javafx.graphics,javafx.web --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.invoke=ALL-UNNAMED --add-opens=javafx.graphics/javafx.application=ALL-UNNAMED --add-opens=javafx.graphics/javafx.geometry=ALL-UNNAMED --add-exports javafx.graphics/com.sun.javafx.sg.prism=ALL-UNNAMED --add-exports javafx.graphics/com.sun.javafx.scene=ALL-UNNAMED --add-exports javafx.graphics/com.sun.javafx.util=ALL-UNNAMED --add-exports javafx.base/com.sun.javafx.logging=ALL-UNNAMED --add-exports javafx.graphics/com.sun.prism=ALL-UNNAMED --add-exports javafx.graphics/com.sun.glass.ui=ALL-UNNAMED --add-exports javafx.graphics/com.sun.javafx.geom.transform=ALL-UNNAMED --add-exports javafx.graphics/com.sun.javafx.tk=ALL-UNNAMED --add-exports javafx.graphics/com.sun.glass.utils=ALL-UNNAMED --add-exports javafx.graphics/com.sun.javafx.font=ALL-UNNAMED --add-exports javafx.controls/com.sun.javafx.scene.control=ALL-UNNAMED --add-exports javafx.graphics/com.sun.javafx.scene.input=ALL-UNNAMED --add-exports javafx.graphics/com.sun.javafx.geom=ALL-UNNAMED --add-exports javafx.graphics/com.sun.javafx.application=ALL-UNNAMED --add-exports javafx.graphics/com.sun.prism.paint=ALL-UNNAMED --add-exports javafx.graphics/com.sun.scenario.effect=ALL-UNNAMED --add-exports javafx.graphics/com.sun.javafx.text=ALL-UNNAMED --add-exports javafx.graphics/com.sun.javafx.iio=ALL-UNNAMED -jar downloadclient.jar --headless $FILE --config=config $@
+        else
+            echo "JAVAFX_HOME is not set. Please read the documentation for further information."
+        fi
     else
         echo "No suitable Java version found. Please read the documentation for further information."
     fi

--- a/misc/scripts/startup-headless.sh
+++ b/misc/scripts/startup-headless.sh
@@ -1,4 +1,27 @@
 #!/bin/sh
 FILE=$1
 shift
-java -jar downloadclient.jar -headless $FILE --config=config $@
+
+if type -p java; then
+    echo "Found 'java' executable in PATH=$PATH"
+    _java=java
+elif [[ -n "$JAVA_HOME" ]] && [[ -x "$JAVA_HOME/bin/java" ]];  then
+    echo "Found 'java' executable in JAVA_HOME=$JAVA_HOME"
+    _java="$JAVA_HOME/bin/java"
+else
+    echo "No Java Runtime (JRE/JDK) installed! Please read the documentation for further information."
+fi
+
+if [[ "$_java" ]]; then
+    version=$("$_java" -version 2>&1 | awk -F '"' '/version/ {print $2}')
+    echo Java version="$version"
+    if [[ "$version" = "1.8"* ]]; then
+        echo "Starting GDI-BY Downloadclient in headless mode using Java version 1.8"
+        $_java -jar downloadclient.jar -headless $FILE --config=config $@
+    elif [[ "$version" = "11.0"* ]]; then
+        echo "Starting GDI-BY Downloadclient in headless mode using Java version 11"
+        $_java -jar downloadclient.jar -headless $FILE --config=config $@
+    else
+        echo "No suitable Java version found. Please read the documentation for further information."
+    fi
+fi

--- a/misc/scripts/startup.bat
+++ b/misc/scripts/startup.bat
@@ -2,6 +2,9 @@
 @echo GDI-BY Downloadclient
 @echo ===============================================
 @echo Setting up an environment.
+@setlocal EnableDelayedExpansion
+
+SET "SYS_PATH=%PATH%"
 SET dlc=%~dp0
 SET dlc=%dlc:\\=\%
 SET "PATH=%dlcbin%;%dlcdll%;%PATH%"
@@ -18,28 +21,36 @@ call %dlc%bin\gisinternals\SDKShell.bat setenv
 where java >nul 2>nul
 if %errorlevel%==1 (
     @echo "No Java Runtime (JRE/JDK) installed! Please read the documentation for further information."
-) else (
+    goto exit
+) 
   for /f "tokens=3" %%g in ('java -version 2^>^&1 ^| findstr /i "version"') do (
     set JAVAVER=%%g
   )
   set JAVAVER=%JAVAVER:"=%
-  @echo Java version: %JAVAVER%
+  @echo Java version=%JAVAVER%
 
-  IF "%JAVAVER:~0,3%"== "1.8" (
+  IF "%JAVAVER:~0,3%"=="1.8" (
     @echo "Starting GDI-BY Downloadclient using Java version 1.8"
-    start javaw -jar downloadclient.jar -config=config
-    pause
+    start javaw -jar downloadclient.jar --config=config
+    goto exit
   ) else (
-    IF "%JAVAVER:~0,4%"== "11.0" (      
-      IF %JAVAFX_HOME% == "" (  
+    IF "%JAVAVER:~0,4%"=="11.0" (      
+      IF "%JAVAFX_HOME%"=="" (  
         @echo "JAVAFX_HOME is not set. Please read the documentation for further information."
+        goto exit
       ) else (
         @echo "Starting GDI-BY Downloadclient using Java version 11"
-        start javaw -cp downloadclient.jar --module-path %JAVAFX_HOME% --add-modules=javafx.base,javafx.controls,javafx.fxml,javafx.graphics,javafx.web --add-opens=java.base/java.lg=ALL-UNNAMED --add-opens=java.base/java.lang.invoke=ALL-UNNAMED --add-opens=javafx.graphics/javafx.application=ALL-UNNAMED --add-opens=javafx.graphics/javafx.geometry=ALL-UNNAMED --add-exports javafx.graphics/com.sun.javafx.sg.prism=ALL-UNNAMED --add-exports javafx.graphics/com.sun.javafx.scene=ALL-UNNAMED --add-exports javafx.graphics/com.sun.javafx.util=ALL-UNNAMED --add-exports javafx.base/com.sun.javafx.logging=ALL-UNNAMED --add-exports javafx.graphics/com.sun.prism=ALL-UNNAMED --add-exports javafx.graphics/com.sun.glass.ui=ALL-UNNAMED --add-exports javafx.graphics/com.sun.javafx.geom.transform=ALL-UNNAMED --add-exports javafx.graphics/com.sun.javafx.tk=ALL-UNNAMED --add-exports javafx.graphics/com.sun.glass.utils=ALL-UNNAMED --add-exports javafx.graphics/com.sun.javafx.font=ALL-UNNAMED --add-exports javafx.controls/com.sun.javafx.scene.control=ALL-UNNAMED --add-exports javafx.graphics/com.sun.javafx.scene.input=ALL-UNNAMED --add-exports javafx.graphics/com.sun.javafx.geom=ALL-UNNAMED --add-exports javafx.graphics/com.sun.javafx.application=ALL-UNNAMED --add-exports javafx.graphics/com.sun.prism.paint=ALL-UNNAMED --add-exports javafx.graphics/com.sun.scenario.effect=ALL-UNNAMED --add-exports javafx.graphics/com.sun.javafx.text=ALL-UNNAMED --add-exports javafx.graphics/com.sun.javafx.iio=ALL-UNNAMED de.bayern.gdi.App
-        pause
+        start javaw --module-path %JAVAFX_HOME%\lib --add-modules=javafx.base,javafx.controls,javafx.fxml,javafx.graphics,javafx.web --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.invoke=ALL-UNNAMED --add-opens=javafx.graphics/javafx.application=ALL-UNNAMED --add-opens=javafx.graphics/javafx.geometry=ALL-UNNAMED --add-exports javafx.graphics/com.sun.javafx.sg.prism=ALL-UNNAMED --add-exports javafx.graphics/com.sun.javafx.scene=ALL-UNNAMED --add-exports javafx.graphics/com.sun.javafx.util=ALL-UNNAMED --add-exports javafx.base/com.sun.javafx.logging=ALL-UNNAMED --add-exports javafx.graphics/com.sun.prism=ALL-UNNAMED --add-exports javafx.graphics/com.sun.glass.ui=ALL-UNNAMED --add-exports javafx.graphics/com.sun.javafx.geom.transform=ALL-UNNAMED --add-exports javafx.graphics/com.sun.javafx.tk=ALL-UNNAMED --add-exports javafx.graphics/com.sun.glass.utils=ALL-UNNAMED --add-exports javafx.graphics/com.sun.javafx.font=ALL-UNNAMED --add-exports javafx.controls/com.sun.javafx.scene.control=ALL-UNNAMED --add-exports javafx.graphics/com.sun.javafx.scene.input=ALL-UNNAMED --add-exports javafx.graphics/com.sun.javafx.geom=ALL-UNNAMED --add-exports javafx.graphics/com.sun.javafx.application=ALL-UNNAMED --add-exports javafx.graphics/com.sun.prism.paint=ALL-UNNAMED --add-exports javafx.graphics/com.sun.scenario.effect=ALL-UNNAMED --add-exports javafx.graphics/com.sun.javafx.text=ALL-UNNAMED --add-exports javafx.graphics/com.sun.javafx.iio=ALL-UNNAMED -jar downloadclient.jar --config=config
+        goto exit
       )
     ) else (
       @echo "No suitable Java version found. Please read the documentation for further information."
+      goto exit
     )
   )
-)
+
+:exit
+@set "PATH=%SYS_PATH%"
+@set SYS_PATH=
+@set _path=
+pause

--- a/misc/scripts/startup.bat
+++ b/misc/scripts/startup.bat
@@ -15,6 +15,31 @@ call %dlc%bin\gisinternals\SDKShell.bat setenv
 @echo This may take a while!
 @echo -----------------------------------------------
 
-start javaw -jar downloadclient.jar -config=config
+where java >nul 2>nul
+if %errorlevel%==1 (
+    @echo "No Java Runtime (JRE/JDK) installed! Please read the documentation for further information."
+) else (
+  for /f "tokens=3" %%g in ('java -version 2^>^&1 ^| findstr /i "version"') do (
+    set JAVAVER=%%g
+  )
+  set JAVAVER=%JAVAVER:"=%
+  @echo Java version: %JAVAVER%
 
-pause
+  IF "%JAVAVER:~0,3%"== "1.8" (
+    @echo "Starting GDI-BY Downloadclient using Java version 1.8"
+    start javaw -jar downloadclient.jar -config=config
+    pause
+  ) else (
+    IF "%JAVAVER:~0,4%"== "11.0" (      
+      IF %JAVAFX_HOME% == "" (  
+        @echo "JAVAFX_HOME is not set. Please read the documentation for further information."
+      ) else (
+        @echo "Starting GDI-BY Downloadclient using Java version 11"
+        start javaw -cp downloadclient.jar --module-path %JAVAFX_HOME% --add-modules=javafx.base,javafx.controls,javafx.fxml,javafx.graphics,javafx.web --add-opens=java.base/java.lg=ALL-UNNAMED --add-opens=java.base/java.lang.invoke=ALL-UNNAMED --add-opens=javafx.graphics/javafx.application=ALL-UNNAMED --add-opens=javafx.graphics/javafx.geometry=ALL-UNNAMED --add-exports javafx.graphics/com.sun.javafx.sg.prism=ALL-UNNAMED --add-exports javafx.graphics/com.sun.javafx.scene=ALL-UNNAMED --add-exports javafx.graphics/com.sun.javafx.util=ALL-UNNAMED --add-exports javafx.base/com.sun.javafx.logging=ALL-UNNAMED --add-exports javafx.graphics/com.sun.prism=ALL-UNNAMED --add-exports javafx.graphics/com.sun.glass.ui=ALL-UNNAMED --add-exports javafx.graphics/com.sun.javafx.geom.transform=ALL-UNNAMED --add-exports javafx.graphics/com.sun.javafx.tk=ALL-UNNAMED --add-exports javafx.graphics/com.sun.glass.utils=ALL-UNNAMED --add-exports javafx.graphics/com.sun.javafx.font=ALL-UNNAMED --add-exports javafx.controls/com.sun.javafx.scene.control=ALL-UNNAMED --add-exports javafx.graphics/com.sun.javafx.scene.input=ALL-UNNAMED --add-exports javafx.graphics/com.sun.javafx.geom=ALL-UNNAMED --add-exports javafx.graphics/com.sun.javafx.application=ALL-UNNAMED --add-exports javafx.graphics/com.sun.prism.paint=ALL-UNNAMED --add-exports javafx.graphics/com.sun.scenario.effect=ALL-UNNAMED --add-exports javafx.graphics/com.sun.javafx.text=ALL-UNNAMED --add-exports javafx.graphics/com.sun.javafx.iio=ALL-UNNAMED de.bayern.gdi.App
+        pause
+      )
+    ) else (
+      @echo "No suitable Java version found. Please read the documentation for further information."
+    )
+  )
+)

--- a/misc/scripts/startup.sh
+++ b/misc/scripts/startup.sh
@@ -17,8 +17,13 @@ if [[ "$_java" ]]; then
         echo "Starting GDI-BY Downloadclient using Java version 1.8"
         $_java -jar downloadclient.jar --config=config
     elif [[ "$version" = "11.0"* ]]; then
-        echo "Starting GDI-BY Downloadclient using Java version 11"
-        $_java -jar downloadclient.jar --config=config
+        if [[ -n "$JAVAFX_HOME" ]]; then
+            echo "Starting GDI-BY Downloadclient using Java version 11"
+            echo "Using JAVAFX in JAVAFX_HOME=$JAVAFX_HOME"
+            $_java --module-path $JAVAFX_HOME/lib --add-modules=javafx.base,javafx.controls,javafx.fxml,javafx.graphics,javafx.web --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.invoke=ALL-UNNAMED --add-opens=javafx.graphics/javafx.application=ALL-UNNAMED --add-opens=javafx.graphics/javafx.geometry=ALL-UNNAMED --add-exports javafx.graphics/com.sun.javafx.sg.prism=ALL-UNNAMED --add-exports javafx.graphics/com.sun.javafx.scene=ALL-UNNAMED --add-exports javafx.graphics/com.sun.javafx.util=ALL-UNNAMED --add-exports javafx.base/com.sun.javafx.logging=ALL-UNNAMED --add-exports javafx.graphics/com.sun.prism=ALL-UNNAMED --add-exports javafx.graphics/com.sun.glass.ui=ALL-UNNAMED --add-exports javafx.graphics/com.sun.javafx.geom.transform=ALL-UNNAMED --add-exports javafx.graphics/com.sun.javafx.tk=ALL-UNNAMED --add-exports javafx.graphics/com.sun.glass.utils=ALL-UNNAMED --add-exports javafx.graphics/com.sun.javafx.font=ALL-UNNAMED --add-exports javafx.controls/com.sun.javafx.scene.control=ALL-UNNAMED --add-exports javafx.graphics/com.sun.javafx.scene.input=ALL-UNNAMED --add-exports javafx.graphics/com.sun.javafx.geom=ALL-UNNAMED --add-exports javafx.graphics/com.sun.javafx.application=ALL-UNNAMED --add-exports javafx.graphics/com.sun.prism.paint=ALL-UNNAMED --add-exports javafx.graphics/com.sun.scenario.effect=ALL-UNNAMED --add-exports javafx.graphics/com.sun.javafx.text=ALL-UNNAMED --add-exports javafx.graphics/com.sun.javafx.iio=ALL-UNNAMED -jar downloadclient.jar --config=config
+        else
+            echo "JAVAFX_HOME is not set. Please read the documentation for further information."
+        fi
     else
         echo "No suitable Java version found. Please read the documentation for further information."
     fi

--- a/misc/scripts/startup.sh
+++ b/misc/scripts/startup.sh
@@ -1,2 +1,25 @@
 #!/bin/sh
-java -jar downloadclient.jar --config=config
+
+if type -p java; then
+    echo "Found 'java' executable in PATH=$PATH"
+    _java=java
+elif [[ -n "$JAVA_HOME" ]] && [[ -x "$JAVA_HOME/bin/java" ]];  then
+    echo "Found 'java' executable in JAVA_HOME=$JAVA_HOME"
+    _java="$JAVA_HOME/bin/java"
+else
+    echo "No Java Runtime (JRE/JDK) installed! Please read the documentation for further information."
+fi
+
+if [[ "$_java" ]]; then
+    version=$("$_java" -version 2>&1 | awk -F '"' '/version/ {print $2}')
+    echo Java version="$version"
+    if [[ "$version" = "1.8"* ]]; then
+        echo "Starting GDI-BY Downloadclient using Java version 1.8"
+        $_java -jar downloadclient.jar --config=config
+    elif [[ "$version" = "11.0"* ]]; then
+        echo "Starting GDI-BY Downloadclient using Java version 11"
+        $_java -jar downloadclient.jar --config=config
+    else
+        echo "No suitable Java version found. Please read the documentation for further information."
+    fi
+fi

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>2.4.1</version>
+                <version>3.2.4</version>
                 <executions>
                     <execution>
                         <phase>package</phase>
@@ -45,6 +45,11 @@
                             <goal>shade</goal>
                         </goals>
                         <configuration>
+                            <artifactSet>
+                                <excludes>
+                                    <exclude>org.openjfx:*</exclude>
+                                </excludes>
+                            </artifactSet>
                             <filters>
                                 <filter>
                                     <artifact>*:*</artifact>
@@ -53,12 +58,6 @@
                                         <exclude>META-INF/*.DSA</exclude>
                                         <exclude>META-INF/*.RSA</exclude>
                                     </excludes>
-                                </filter>
-                                <filter>
-                                    <artifact>org.openjfx</artifact>
-                                    <includes>
-                                        <include>**</include>
-                                    </includes>
                                 </filter>
                             </filters>
                             <transformers>

--- a/pom.xml
+++ b/pom.xml
@@ -175,7 +175,40 @@
                             </rules>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>enforce-ban-duplicate-classes</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <banDuplicateClasses>
+                                    <ignoreClasses>
+                                    <!--
+                                        <ignoreClass>org.apache.commons.logging.*</ignoreClass>
+                                        <ignoreClass>org.w3c.dom.*</ignoreClass>
+                                    -->
+                                        <ignoreClass>it.geosolutions.jaiext.scale.JaiI18N</ignoreClass>
+                                    </ignoreClasses>
+                                    <scopes>
+                                        <scope>compile</scope>
+                                        <scope>provided</scope>
+                                    </scopes>
+                                    <findAllDuplicates>true</findAllDuplicates>
+                                    <ignoreWhenIdentical>true</ignoreWhenIdentical>
+                                </banDuplicateClasses>
+                            </rules>
+                            <fail>true</fail>
+                        </configuration>
+                    </execution>
                 </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>extra-enforcer-rules</artifactId>
+                        <version>1.3</version>
+                    </dependency>
+                </dependencies>
             </plugin>
         </plugins>
         <resources>
@@ -467,6 +500,24 @@
                         </plugin>
                     </plugins>
                 </pluginManagement>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-jdeps-plugin</artifactId>
+                        <version>3.1.2</version>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>jdkinternals</goal> <!-- verify main classes -->
+                                    <goal>test-jdkinternals</goal> <!-- verify test classes -->
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <multiRelease>${jdk.version}</multiRelease>
+                        </configuration>
+                    </plugin>
+                </plugins>
             </build>
             <dependencies>
                 <dependency>

--- a/src/resources/module-info.java
+++ b/src/resources/module-info.java
@@ -1,0 +1,9 @@
+module dlcfx {
+    requires javafx.controls;
+    requires javafx.fxml;
+    requires org.geotools.geometry;
+    requires com.sothawo.mapjfx;
+
+    opens de.bayern.gdi to javafx.fxml;
+    exports de.bayern.gdi;
+}

--- a/src/resources/module-info.java
+++ b/src/resources/module-info.java
@@ -1,9 +1,0 @@
-module dlcfx {
-    requires javafx.controls;
-    requires javafx.fxml;
-    requires org.geotools.geometry;
-    requires com.sothawo.mapjfx;
-
-    opens de.bayern.gdi to javafx.fxml;
-    exports de.bayern.gdi;
-}


### PR DESCRIPTION
PR fixes issues when starting DLC with Java 11 on Windows and Linux where JavaFX SDK is required.