### PR TITLE
#61 removed jdeps plugin to avoid conflicts with older JDK 11 versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -513,24 +513,6 @@
                         </plugin>
                     </plugins>
                 </pluginManagement>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-jdeps-plugin</artifactId>
-                        <version>3.1.2</version>
-                        <executions>
-                            <execution>
-                                <goals>
-                                    <goal>jdkinternals</goal> <!-- verify main classes -->
-                                    <goal>test-jdkinternals</goal> <!-- verify test classes -->
-                                </goals>
-                            </execution>
-                        </executions>
-                        <configuration>
-                            <multiRelease>${jdk.version}</multiRelease>
-                        </configuration>
-                    </plugin>
-                </plugins>
             </build>
             <dependencies>
                 <dependency>


### PR DESCRIPTION
Plugin execution during build is not longer required since start scripts contain the required unnamed-module parameters