### PR TITLE
Exclude jakarta.xml.bind-api from xmlunit-core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -440,6 +440,12 @@
             <groupId>org.xmlunit</groupId>
             <artifactId>xmlunit-core</artifactId>
             <version>2.8.2</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>jakarta.xml.bind</groupId>
+                    <artifactId>jakarta.xml.bind-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.xmlunit</groupId>


### PR DESCRIPTION
Fixes https://github.com/gdi-by/downloadclient-dev/issues/66